### PR TITLE
Fixing content type mismatch issue on auth.phtml

### DIFF
--- a/app/design/adminhtml/default/default/template/he_twofactor/google/auth.phtml
+++ b/app/design/adminhtml/default/default/template/he_twofactor/google/auth.phtml
@@ -55,7 +55,7 @@
     <link rel="icon" href="<?php echo $this->getSkinUrl('favicon.ico'); ?>" type="image/x-icon" />
     <link rel="shortcut icon" href="<?php echo $this->getSkinUrl('favicon.ico'); ?>" type="image/x-icon" />
 
-    <script type="text/javascript" src="<?php echo $this->getJsUrl(); ?>index.php/x.js?f=prototype/prototype.js,prototype/validation.js,mage/adminhtml/events.js,mage/adminhtml/form.js,scriptaculous/effects.js"></script>
+    <script type="text/javascript" src="<?php echo $this->getJsUrl(); ?>index.php/x.js?c=auto&f=prototype/prototype.js,prototype/validation.js,mage/adminhtml/events.js,mage/adminhtml/form.js,scriptaculous/effects.js"></script>
     <script type="text/javascript" src="<?php echo $this->getJsUrl('mage/captcha.js') ?>"></script>
 
     <!--[if IE]> <link rel="stylesheet" href="<?php echo $this->getSkinUrl('iestyles.css'); ?>" type="text/css" media="all" /> <![endif]-->


### PR DESCRIPTION
Making the x.js script automatically detect and pass back the correct content type so that it isn't necessary to comment out the "Header set X-Content-Type-Options: nosniff" line in htaccess.
Fixes issue 14.